### PR TITLE
Adding Google Adsense support, improvements to substitutions, and child url for amp page+content

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then add this theme in your `themes/(your-theme)/layout/_partial/head.ejs`.
 
 ``` ejs
   <% if (is_post() && config.generator_amp){ %>
-    <link rel="amphtml" href="./index.amp.html">
+    <link rel="amphtml" href="./amp/index.html">
   <% } %>
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ Output file path is the `./index.amp.html`. Validate your AMP pages. Please see 
 ``` yaml
 # Advanced Settings of hexo-amp-generator
 generator_amp:
+  substituteGoogle_adsense:
+    data_ad_client: ca-pub-123456789876543
+    data_ad_slot: 0123456789
+    width: 336
+    height: 280
   logo:
     path: asset/path-to-your-site-logo.jpg
     width: 600
@@ -95,6 +100,11 @@ copyright_notice: The footer copyright notice #(optional)
 ### A description of the options
 
 #### generator_amp settings
+- substituteGoogle_adsense
+  - **substituteGoogle_adsense.data_ad_client**: substitute data_ad_client id
+  - **substituteGoogle_adsense.data_ad_slot**: substitute data_ad_slot id
+  - **substituteGoogle_adsense.width**: substitute ad width
+  - **substituteGoogle_adsense.height**: substitute ad height
 - logo
   - **logo.path**: File path of a your logo image.
   - **logo.width**: Width of a your logo image. ([width <= 600px](https://developers.google.com/structured-data/carousels/top-stories#logo_guidelines))

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -12,6 +12,7 @@ module.exports = function(locals){
   var cssFilePath = pathFn.join(__dirname, '../sample-amp.css');
   var template    = "";
   var templateDir = __dirname;
+  var idDecorator = 0;
   
   //------------------------------------
   // import template file
@@ -88,15 +89,38 @@ module.exports = function(locals){
     //------------------------------------
     // Sanitize tag
     //------------------------------------
-    replaceStr = replaceStr.replace(/\<style\>.*?\<\/style\>/g, "");
-    replaceStr = replaceStr.replace(/\<script\>.*?\<\/script\>/g, "");
-    replaceStr = replaceStr.replace(/\<div\s.*?\>/g, "");
-    replaceStr = replaceStr.replace(/\<\/div\>/g, "");
-    replaceStr = replaceStr.replace(/\<span\s.*?\>/g, "");
-    replaceStr = replaceStr.replace(/\<\/span\>/g, "");
-    
-    //delete a tag
-    replaceStr = replaceStr.replace(/\<a\s((?!>).)*?\>\<\/a\>/g, "");
+
+    replaceStr = replaceStr.replace(/\<[\s]*style[^\<]*\<\/[\s]*style[\s]*\>/g, "");
+    replaceStr = replaceStr.replace(/\<[\s]*script[^\<]*\<\/[\s]*script[\s]*\>/g, "");
+
+    // Remove style from tags (adding ids and promoting to css)
+    replaceStr = replaceStr.replace(/\<\s*([^\s\>]+)((?:[^\>]*\bid[ \t]*="([^"\\]*(?:\\.[^"\\]*)*)"|[^\>]*)[^\>]*)style="([^"\\]*(?:\\.[^"\\]*)*)"((?:[^\>]*\bid[ \t]*="([^"\\]*(?:\\.[^"\\]*)*)"|[^\>]*)[^\>]*\>)/g, function ($1, $2, $3, $4, $5, $6){
+      //$1 -> type
+      //$2 -> content between type and style (aka id, class, etc.)
+      //$3 -> id if on left side of style OR empty
+      //$4 -> content of style (you can add this to id OR create a new id for this tag to add to)
+      //$5 -> content to end the tag (aka id, class, etc.)
+      //$6 -> id if on right side of style OR empty
+      var id = (arguments[3] === "") ? arguments[6] : arguments[3];
+      var newID = null;
+      var idStyle = arguments[4].replace(/\!important/g, "");
+      if(id && (typeof id != 'undefined') && id != "")
+      {
+        //console.log("Found an id");
+        cssTxt += "#" + id + "{" + idStyle + "}";
+      }
+      else
+      {
+        //console.log("Generate a unique qualified id for the amp generator");
+        newID = "hexo-amp-id-" + (++idDecorator);
+        cssTxt += "#" + newID + "{" + idStyle + "}";
+      }
+      //console.log("Style: " + arguments[4]);
+      return "<" + arguments[1] + (newID ? " id=\"" + newID + '"' : "") + " " + arguments[2] + " " + arguments[5];
+    });
+
+    //delete a tags that contain "javascript:""
+    replaceStr = replaceStr.replace(/\<a\s*href\s*=\s*"javascript:[^\>]*\>/g, "");
     
     
     

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -253,7 +253,7 @@ module.exports = function(locals){
     });
     
     return {
-      path: post.path+"index.amp.html",
+      path: post.path+"amp/index.html",
       data: xml
     };
   });

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -58,6 +58,34 @@ module.exports = function(locals){
     }
 
     //------------------------------------
+    // Google Adsense
+    //------------------------------------
+
+    replaceStr = replaceStr.replace(/\<[^\s\>]*ins[^\S\>]*class="adsbygoogle"[^\S\>]*style="([^"\\]*(?:\\.[^"\\]*)*)"[^\>]*data-ad-client="([^"\\]*(?:\\.[^"\\]*)*)"[^\>]*data-ad-slot="([^"\\]*(?:\\.[^"\\]*)*)"[^\<]*\<\/ins\>/g, function ($1, $2, $3){
+      
+      var adWidth;
+      var adHeight;
+      if(arguments[1])
+      {
+        var matches = /width:([0-9]*)/g.exec(arguments[1]);
+        adWidth = matches ? matches[1] : config.generator_amp.substituteGoogle_adsense.width;
+
+        matches = /height:([0-9]*)/g.exec(arguments[1]);
+        adHeight = matches ? matches[1] : config.generator_amp.substituteGoogle_adsense.height;
+      }
+      else
+      {
+        adWidth = config.generator_amp.substituteGoogle_adsense.width;
+        adHeight = config.generator_amp.substituteGoogle_adsense.height;
+      }
+
+      var adClient = arguments[2] ? arguments[2] : config.generator_amp.substituteGoogle_adsense.data_ad_client;
+      var adSlot = arguments[3] ? arguments[3] : config.generator_amp.substituteGoogle_adsense.data_ad_slot;
+
+      return "<amp-ad width=\"" + adWidth + "\" height=\"" + adHeight + "\" type=\"adsense\" data-ad-client=\"" + adClient + "\" data-ad-slot=\"" + adSlot + "\"></amp-ad>";
+    });
+
+    //------------------------------------
     // Sanitize tag
     //------------------------------------
     replaceStr = replaceStr.replace(/\<style\>.*?\<\/style\>/g, "");


### PR DESCRIPTION
- Added support to seek out google adsense tags and replace with amp versions.
- Fixed script and style removal logic to be more generic.
- Allowing div and other tags but removing ONLY the style attribute while adding the style to ids and appending to css.
