### PR TITLE
Windows Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ if(hexo.config.generator_amp && hexo.config.generator_amp.onlyForDeploy){
 	lg.log("info", "'onlyForDeploy' option deprecated. Please set the 'cache' option." , null);
 }
 
-console.log('__dirname=' + __dirname);
 //default path
 var ejsPath     = '../template/sample-amp.ejs';
 var cssPath     = '../template/sample-amp.css';

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ if(hexo.config.generator_amp && hexo.config.generator_amp.onlyForDeploy){
 	lg.log("info", "'onlyForDeploy' option deprecated. Please set the 'cache' option." , null);
 }
 
-
+console.log('__dirname=' + __dirname);
 //default path
 var ejsPath     = '../template/sample-amp.ejs';
 var cssPath     = '../template/sample-amp.css';

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -15,7 +15,7 @@ function existsOption(hexoConfig){
 }
 
 function getCachePath(hexoConfig){
-  return pathFn.join(process.env.PWD , hexoConfig.generator_amp.cache);
+  return pathFn.join(process.cwd() , hexoConfig.generator_amp.cache);
 }
 
 

--- a/lib/copyAssets.js
+++ b/lib/copyAssets.js
@@ -8,16 +8,19 @@ var absolutePathReg = /^[a-zA-Z0-9]*?\:\/\//
 var config;
 
 function isHexoWorkingDir(){
-  var themeDir = pathFn.join(process.env.PWD , "themes")
+  var themeDir = pathFn.join(process.cwd() , "themes")
   var flg = fs.existsSync(themeDir);
   return flg;
 }
 
 module.exports.initCopy = function(assetDirName, assetFiles){
   
-  var hexoAssetPath = pathFn.join(process.env.PWD , assetDirName);
-  var hexoAssetPath_sampleDir = pathFn.join(process.env.PWD , assetDirName , "sample");
-  
+  var hexoAssetPath = assetDirName;
+  var hexoAssetPath_sampleDir = pathFn.join(assetDirName, "sample");
+  if(!pathFn.isAbsolute(assetDirName)) {
+    hexoAssetPath = pathFn.join(process.cwd() , assetDirName);
+    hexoAssetPath_sampleDir = pathFn.join(process.cwd() , assetDirName , "sample");
+  }
   if(!fs.existsSync(hexoAssetPath) && isHexoWorkingDir() ){
     //create dir
     mkdirp.sync( hexoAssetPath_sampleDir );
@@ -34,15 +37,15 @@ module.exports.initCopy = function(assetDirName, assetFiles){
 };
 
 module.exports.copyAssets = function(assetDirName, distDirName ,copyFiles){
-  var hexoAssetPath = pathFn.join(process.env.PWD , assetDirName);
+  var hexoAssetPath = pathFn.join(process.cwd() , assetDirName);
   if(fs.existsSync(hexoAssetPath)){
     //copy asset dir
-    if( !fs.existsSync(pathFn.join(process.env.PWD , "source" , distDirName))  && isHexoWorkingDir() )mkdirp.sync( pathFn.join(process.env.PWD , "source" , distDirName) );
+    if( !fs.existsSync(pathFn.join(process.cwd() , "source" , distDirName))  && isHexoWorkingDir() )mkdirp.sync( pathFn.join(process.cwd() , "source" , distDirName) );
     for(var i=0; i< copyFiles.length; i++){
       if(fs.existsSync( pathFn.join(hexoAssetPath , copyFiles[i]) )  && isHexoWorkingDir() ){
-        // fs.createReadStream( pathFn.join(hexoAssetPath , copyFiles[i]) ).pipe(fs.createWriteStream( pathFn.join(process.env.PWD , "source" , distDirName , pathFn.basename(copyFiles[i])) ));
-        mkdirp.sync( pathFn.dirname( pathFn.join(process.env.PWD , "source" , distDirName , copyFiles[i])));
-        fs.createReadStream( pathFn.join(hexoAssetPath , copyFiles[i]) ).pipe(fs.createWriteStream( pathFn.join(process.env.PWD , "source" , distDirName , copyFiles[i]) ));
+        // fs.createReadStream( pathFn.join(hexoAssetPath , copyFiles[i]) ).pipe(fs.createWriteStream( pathFn.join(process.cwd() , "source" , distDirName , pathFn.basename(copyFiles[i])) ));
+        mkdirp.sync( pathFn.dirname( pathFn.join(process.cwd() , "source" , distDirName , copyFiles[i])));
+        fs.createReadStream( pathFn.join(hexoAssetPath , copyFiles[i]) ).pipe(fs.createWriteStream( pathFn.join(process.cwd() , "source" , distDirName , copyFiles[i]) ));
       }else if( absolutePathReg.test(copyFiles[i]) ){
         // External path
       }else{

--- a/lib/imageSize.js
+++ b/lib/imageSize.js
@@ -18,7 +18,7 @@ module.exports.getSizeInfo = function(imgsrc , data){
     
   }else{
     // console.log("画像パス判定(2): "+ "source/**/に画像がある");
-    imgDevPath = pathFn.join(process.env.PWD , "source/" , imgsrc);
+    imgDevPath = pathFn.join(process.cwd() , "source/" , imgsrc);
   }
   // console.log("  ファイルパス ->"+ imgDevPath );
   // console.log(" 入力値： " + imgsrc);

--- a/lib/templatePath.js
+++ b/lib/templatePath.js
@@ -30,8 +30,8 @@ module.exports.getPath = function(inConfig){
   if(config.generator_amp && config.generator_amp.templateFilePath){
     ejsTemplateRelativePath = config.generator_amp.templateFilePath;
   }
-  ampEjsTmplPath  = pathFn.join(process.env.PWD , config.generator_amp.templateDir , ejsTemplateRelativePath);
-  templateDir     = pathFn.join(process.env.PWD , config.generator_amp.templateDir);
+  ampEjsTmplPath  = pathFn.join(process.cwd() , config.generator_amp.templateDir , ejsTemplateRelativePath);
+  templateDir     = pathFn.join(process.cwd() , config.generator_amp.templateDir);
   if(fs.existsSync(ampEjsTmplPath)){
     template        = ejs.compile(fs.readFileSync(ampEjsTmplPath, 'utf8'), {filename: templateDir});
   }else{
@@ -42,9 +42,9 @@ module.exports.getPath = function(inConfig){
   //------------------------------------
   // import CSS file
   //------------------------------------
-  cssFilePath = pathFn.join(process.env.PWD , config.generator_amp.templateDir, "sample/" + pathFn.basename(config.generator_amp.defaultAssetsPath.css) );
+  cssFilePath = pathFn.join(process.cwd() , config.generator_amp.templateDir, "sample/" + pathFn.basename(config.generator_amp.defaultAssetsPath.css) );
   if(config.generator_amp && config.generator_amp.cssFilePath){
-    cssFilePath = pathFn.join(process.env.PWD , config.generator_amp.templateDir,config.generator_amp.cssFilePath);
+    cssFilePath = pathFn.join(process.cwd() , config.generator_amp.templateDir,config.generator_amp.cssFilePath);
   }
   
   var cssTxt = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo-generator-amp",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index",
   "dependencies": {
     "cheerio": "^0.22.0",
@@ -13,6 +13,7 @@
     "image-size": "^0.5.0",
     "log-util": "^1.1.2",
     "mkdirp": "^0.5.1",
+    "moment": "^2.17.1",
     "object-assign": "^4.1.0"
   },
   "description": "AMP ⚡ HTML (Accelerated Mobile Pages) generator for Hexo.",


### PR DESCRIPTION
I replaced all of the instances of process.env.PWD, which doesn’t exist on Windows, with process.cwd() which, according to the Node.js docs (https://nodejs.org/dist/latest-v7.x/docs/api/process.html#process_process_cwd), is the correct cross-platform way to get the current working directory.