### PR TITLE
fix external detection on url prefix with '//' & fix error when img has no src attribute

### DIFF
--- a/lib/eyeCatchVars.js
+++ b/lib/eyeCatchVars.js
@@ -89,9 +89,8 @@ module.exports = function(post){
 
 function getImgSize(results){
   return new Promise(function(resolve, reject){
-    if(results.length == 1)resolve(results[0]);
-    
-    var externalPathReg = /^[a-zA-Z0-9]*?\:\/\//;
+    if(results.length == 1 || !results[1])resolve(results[0]);
+    var externalPathReg = /^(?:\/\/|[a-zA-Z0-9]*?\:\/\/)/;
     var post            = results[0];
     var titleImagePath  = results[1];
     var imgWidth        = results[2];
@@ -100,8 +99,11 @@ function getImgSize(results){
     var cache           = results[5];
     var config          = results[6];
     var lg              = results[7];
-    
+
     if(externalPathReg.test(titleImagePath)){
+      if(/^\/\//.test(titleImagePath)){
+        titleImagePath = 'http:' + titleImagePath;
+      }
       post.eyeCatchImage       = titleImagePath;
       post.titleImageForAmp    = titleImagePath;
     }else{
@@ -158,11 +160,15 @@ function isAmpHeightValid( inHeight , inLg , inPost ){
 
 
 function setSubstituteTitleImage(inConfig , inPost){
-  var externalPathReg = /^[a-zA-Z0-9]*?\:\/\//;
+  var externalPathReg = /^(?:\/\/|[a-zA-Z0-9]*?\:\/\/)/;
   if( inConfig.generator_amp && inConfig.generator_amp.substituteTitleImage && inConfig.generator_amp.substituteTitleImage.path && inConfig.generator_amp.substituteTitleImage.width  && inConfig.generator_amp.substituteTitleImage.height ){
     if(externalPathReg.test(inConfig.generator_amp.substituteTitleImage.path)){
-      inPost.eyeCatchImage = inConfig.generator_amp.substituteTitleImage.path;
-      inPost.titleImageForAmp = inConfig.generator_amp.substituteTitleImage.path;
+      var substituteTitleImage = inConfig.generator_amp.substituteTitleImage.path;
+      if(/^\/\//.test(substituteTitleImage)){
+        substituteTitleImage = 'http:' + substituteTitleImage;
+      }
+      inPost.eyeCatchImage = substituteTitleImage;
+      inPost.titleImageForAmp = substituteTitleImage;
     }else{
       inPost.eyeCatchImage = inConfig.url + pathFn.join(inConfig.root , inConfig.generator_amp.assetDistDir ,inConfig.generator_amp.substituteTitleImage.path);
       inPost.titleImageForAmp = pathFn.join(inConfig.root , inConfig.generator_amp.assetDistDir ,inConfig.generator_amp.substituteTitleImage.path);

--- a/lib/imageSize.js
+++ b/lib/imageSize.js
@@ -7,7 +7,7 @@ var http            = require('http');
 var https           = require('https');
 var imgSize         = require('image-size');
 var lg              = require('./log.js');
-var externalPathReg = /^[a-zA-Z0-9]*?\:\/\//;
+var externalPathReg = /^(?:\/\/|[a-zA-Z0-9]*?\:\/\/)/;
 var config;
 
 
@@ -33,6 +33,9 @@ module.exports.getSizeInfo = function(imgsrc , data , callback){
   }else{
     // External image
     imgDevPath = imgsrc;
+    if(/^\/\//.test(imgDevPath)){
+      imgDevPath = 'http:' + imgDevPath;
+    }
   }
   
   


### PR DESCRIPTION
Some background:

1. I use url like '//xxx.com/xxx.jpg' to refer an image, cause this format can work well on both `http` and `https` sites.
2. I wrote a lazy load plugin to defer the loading of images. So there exists no `src` attribute on `img`, instead there is a `data-src` attribute. (This PR does nothing on `data-src`, just skip the img without src.)